### PR TITLE
oh my god it works finally the encoding is fix . e.d.  .. .

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,10 @@ plugins {
     id 'org.openjfx.javafxplugin' version '0.0.13'
 }
 
+tasks.withType(JavaCompile) {
+    options.encoding = 'UTF-8'
+}
+
 repositories {
     mavenCentral()
 }
@@ -35,4 +39,5 @@ test {
     testLogging {
         events "passed", "skipped", "failed"
     }
+    systemProperty "file.encoding", "utf-8"
 }

--- a/src/main/java/gateways/MessageTranslateGoogleCloud.java
+++ b/src/main/java/gateways/MessageTranslateGoogleCloud.java
@@ -24,11 +24,11 @@ public class MessageTranslateGoogleCloud implements MessageTranslateGateway {
     public String translate(MessageTranslateData data){
         String original = data.getOriginal();
         String targetLanguage = data.getTargetLanguage();
-        String sourceLanguage = data.getSourceLanguage();
+//        String sourceLanguage = data.getSourceLanguage();
 
         Translation translation = translate.translate(
                 original,
-                TranslateOption.sourceLanguage(sourceLanguage),
+//                TranslateOption.sourceLanguage(sourceLanguage),
                 TranslateOption.targetLanguage(targetLanguage));
 
         return translation.getTranslatedText();


### PR DESCRIPTION
# Description

I adjusted our build.gradle file to specify the encoding to UTF-8 and now I think we can properly process strings. We had an issue before where our default encoding was windows-1852 or something and strings in unicode were not being processed correctly.

Edit 1: Modified the gateway to no longer require a source language, now guesses the source language instead.

# Design Patterns

No relevant changes

# SOLID Principles

No relevant changes

# Breaking Change
- [ ] Check this if your changes will cause merge conflicts in other branches.

# Checklist:
- [x] My code follows Java style conventions
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added Javadocs for new classes and methods
- [x] My changes generate no new relevant warnings
- [x] I have added tests for any new functionality added
- [x] New and existing unit tests pass locally with my changes

